### PR TITLE
Fix casing normalization validation + add missing dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jet-env",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jet-env",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.8.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/seanpmaxwell/jet-env#readme",
   "devDependencies": {
     "@types/node": "^22.8.1",
+    "dotenv": "^16.4.5",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.0",
     "typescript": "^5.6.3"

--- a/src/jetEnv.ts
+++ b/src/jetEnv.ts
@@ -108,15 +108,15 @@ function _toBool(arg: unknown): boolean | undefined {
     const argF = arg.toLowerCase();
     if (argF === 'true') {
       return true;
-    } else if (arg === 'false') {
+    } else if (argF === 'false') {
       return false;
     } else if (arg === '0') {
       return false;
     } else if (arg === '1') {
       return true;
-    } else if (arg === 'yes') {
+    } else if (argF === 'yes') {
       return true;
-    } else if (arg === 'no') {
+    } else if (argF === 'no') {
       return false;
     }
   }

--- a/test/.env
+++ b/test/.env
@@ -1,5 +1,6 @@
 NODE_ENV=development
 IS_LOCAL=false
+DRY_RUN_ENABLED=FALSE
 PORT=1
 BACK_END_URL=localhost:3000
 FRONT_END_URL=localhost:3001

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,6 +15,7 @@ if (!!result?.error) {
 const Env = jetEnv({
   NodeEnv: str,
   IsLocal: bool,
+  DryRunEnabled: bool,
   Port: num,
   BackEndUrl: str,
   FrontEndUrl: str,
@@ -33,6 +34,7 @@ const Env = jetEnv({
 
 console.log(Env);
 console.log(Env.IsLocal);
+console.log(Env.DryRunEnabled);
 console.log(Env.Port);
 console.log(Env.S3BucketExp)
 console.log(Env.Aws.S3Credentials.AccessKeyId)


### PR DESCRIPTION
Hi, I noticed that your library actually doesn't properly utilize the normalized casing version of environment variables, as it will throw an error when it comes across a variable with value of `TRUE`, `FALSE`, `YES`, or `NO`, due to the code not using the normalized `argF` in the string comparison conditions.

On top of fixing this bug, I also updated the version in the `package-lock.json` file to match the current version of the package, and added the `dotenv` dependency as a `devDependency` since it gets used in the test file and is needed for local development on the package.